### PR TITLE
fix breadcrumb build

### DIFF
--- a/projects/widgets/breadcrumb/breadcrumb-defaults.ts
+++ b/projects/widgets/breadcrumb/breadcrumb-defaults.ts
@@ -2,10 +2,9 @@ import { IdsBreadcrumbDividerType, IdsBreadcrumbDivider } from './types/breadcru
 import { IdsBreadcrumbHierarchyType } from './types/breadcrumb-hierarchy.type';
 import { IdsBreadcrumbVariantType, IdsBreadcrumbVariant } from './types/breadcrumb-variant.type';
 
-import { IdsOverlayPanelAppearance, IdsOverlayPanelAppearanceType, IdsOverlayPanelVariant, IdsOverlayPanelVariantType } from '../overlay-panel';
-
 import { InjectionToken } from '@angular/core';
 import { IdsSizeType, IdsSize } from '@i-cell/ids-angular/core';
+import { IdsOverlayPanelAppearance, IdsOverlayPanelAppearanceType, IdsOverlayPanelVariant, IdsOverlayPanelVariantType } from '@i-cell/ids-angular/overlay-panel';
 
 export interface IdsBreadcrumbDefaultConfig {
   hierarchy: IdsBreadcrumbHierarchyType[];

--- a/projects/widgets/breadcrumb/breadcrumb.component.ts
+++ b/projects/widgets/breadcrumb/breadcrumb.component.ts
@@ -4,14 +4,15 @@ import { IdsBreadcrumbLinkDirective } from './libs/breadcrumb-link.directive';
 import { IdsBreadcrumbListDirective } from './libs/breadcrumb-list.directive';
 import { IdsBreadcrumbPageDirective } from './libs/breadcrumb-page.directive';
 import { IdsBreadcrumbTruncationComponent } from './libs/breadcrumb-truncation.component';
-import { IdsBreadcrumbDivider, IdsBreadcrumbDividerType, IdsBreadcrumbHierarchyType, IdsBreadcrumbVariantType } from './public-api';
-
-import { IdsOverlayPanelAppearanceType, IdsOverlayPanelVariantType } from '../overlay-panel';
-import { IdsTooltipDirective } from '../tooltip';
+import { IdsBreadcrumbDivider, IdsBreadcrumbDividerType } from './types/breadcrumb-divider.type';
+import { IdsBreadcrumbHierarchyType } from './types/breadcrumb-hierarchy.type';
+import { IdsBreadcrumbVariantType } from './types/breadcrumb-variant.type';
 
 import { NgTemplateOutlet } from '@angular/common';
 import { Component, computed, ElementRef, inject, input, signal } from '@angular/core';
 import { ComponentBaseWithDefaults, createClassList, IdsSizeType, ResizeObserverService } from '@i-cell/ids-angular/core';
+import { IdsOverlayPanelAppearanceType, IdsOverlayPanelVariantType } from '@i-cell/ids-angular/overlay-panel';
+import { IdsTooltipDirective } from '@i-cell/ids-angular/tooltip';
 
 const defaultConfig = IDS_BREADCRUMB_DEFAULT_CONFIG_FACTORY();
 

--- a/projects/widgets/breadcrumb/public-api.ts
+++ b/projects/widgets/breadcrumb/public-api.ts
@@ -1,4 +1,5 @@
 export * from './types/breadcrumb-divider.type';
 export * from './types/breadcrumb-hierarchy.type';
 export * from './types/breadcrumb-variant.type';
+export * from './breadcrumb-defaults';
 export * from './breadcrumb.component';


### PR DESCRIPTION
Breadcrumb `build:prod:widgets` command gave the following error: 

`Cannot destructure property 'pos' of 'file.referencedFiles[index]' as it is undefined.`

This error can be fixed by resolving relative paths outside current (breadcrumb) package.