### PR TITLE
fix(side-nav): fix warning when target is not provided to side-nav-item

### DIFF
--- a/projects/demo/src/app/pages/side-nav/side-nav-demo.component.html
+++ b/projects/demo/src/app/pages/side-nav/side-nav-demo.component.html
@@ -77,7 +77,7 @@
               </ids-side-nav-item>
               <ids-side-nav-item
                 label="Avatar"
-                target="components/avatar"
+                target="components/avatar/demo"
                 [disabled]="_sideNavDemoService.helperModel.disabled"
                 [hasTooltip]="_sideNavDemoService.helperModel.hasTooltip"
               >
@@ -90,7 +90,7 @@
               </ids-side-nav-item>
               <ids-side-nav-item
                 label="Side Navigation"
-                target="components/side-nav"
+                target="components/side-nav/demo"
                 [disabled]="_sideNavDemoService.helperModel.disabled"
                 [hasTooltip]="_sideNavDemoService.helperModel.hasTooltip"
               >
@@ -176,7 +176,7 @@
                 <li
                   idsSideNavItem
                   label="Avatar"
-                  target="components/avatar"
+                  target="components/avatar/demo"
                   [disabled]="_sideNavDemoService.helperModel.disabled"
                   [hasTooltip]="_sideNavDemoService.helperModel.hasTooltip"
                 >
@@ -190,7 +190,7 @@
                 <li
                   idsSideNavItem
                   label="Side Navigation"
-                  target="components/side-nav"
+                  target="components/side-nav/demo"
                   [disabled]="_sideNavDemoService.helperModel.disabled"
                   [hasTooltip]="_sideNavDemoService.helperModel.hasTooltip"
                 >

--- a/projects/demo/src/app/pages/side-nav/side-nav-demo.service.ts
+++ b/projects/demo/src/app/pages/side-nav/side-nav-demo.service.ts
@@ -60,7 +60,7 @@ export class SideNavDemoService {
       description: 'Router link of side nav item',
       type: 'string',
       default: '-',
-      demoDefault: 'components/accordion',
+      demoDefault: 'components/accordion/demo',
     },
     hasLeadingIcon: {
       description: 'Whether the side nav item has leading icon or not.',

--- a/projects/widgets/side-nav/side-nav-item.component.ts
+++ b/projects/widgets/side-nav/side-nav-item.component.ts
@@ -16,7 +16,7 @@ import {
   TemplateRef,
   untracked,
 } from '@angular/core';
-import { IsActiveMatchOptions } from '@angular/router';
+import { isActive, IsActiveMatchOptions } from '@angular/router';
 import { coerceBooleanAttribute } from '@i-cell/ids-angular/core';
 import { IdsIconComponent } from '@i-cell/ids-angular/icon';
 import { IdsIconButtonComponent } from '@i-cell/ids-angular/icon-button';
@@ -87,6 +87,9 @@ import { IdsTooltipDirective } from '@i-cell/ids-angular/tooltip';
   },
 })
 export class IdsSideNavItemComponent {
+  protected readonly _parent = inject(IDS_SIDE_NAV_PARENT, { optional: true });
+  private readonly _router = inject(IDS_SIDE_NAV_ROUTER, { skipSelf: true });
+
   public disabled = input(false, { transform: (value: boolean | string) => coerceBooleanAttribute(value) });
   public label = input.required<string>();
   public hasTooltip = input<unknown, boolean>(false, { transform: booleanAttribute });
@@ -99,23 +102,14 @@ export class IdsSideNavItemComponent {
     matrixParams: 'ignored',
   });
 
-  public active = computed(() => {
-    this._parent?.navigationChange();
-    return this._router.isActive(this.target(), this.isActiveMatchOptions());
-  });
+  public active = computed(() => (this.target() ? isActive(this.target(), this._router, this.isActiveMatchOptions())() : false));
 
   protected _expandable = computed(() => this._contentChildren().length > 0 || this._contentTemplate());
-  protected _expanded = linkedSignal(() => {
-    this._parent?.navigationChange();
-    return this._contentChildren().some((child) => child.active());
-  });
-
+  protected _expanded = linkedSignal(() => this._contentChildren().some((child) => child.active()));
   protected _iconLeading = contentChildren<IdsIconComponent>('[icon-leading]');
   protected _iconTrailing = contentChildren<IdsIconComponent>('[icon-trailing]');
-  protected readonly _parent = inject(IDS_SIDE_NAV_PARENT, { optional: true });
   protected readonly _contentTemplate = contentChild('idsSideNavItemChildren', { read: TemplateRef });
   private readonly _contentChildren = contentChildren(IdsSideNavItemComponent);
-  private readonly _router = inject(IDS_SIDE_NAV_ROUTER, { skipSelf: true });
   private _elementRef = inject(ElementRef);
 
   constructor() {

--- a/projects/widgets/side-nav/side-nav.component.ts
+++ b/projects/widgets/side-nav/side-nav.component.ts
@@ -5,8 +5,7 @@ import { IdsSideNavAppearanceType } from './types/side-nav-appearance.type';
 import { IdsSideNavVariantType } from './types/side-nav-variant.type';
 
 import { booleanAttribute, Component, computed, inject, input } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { NavigationEnd, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { ComponentBaseWithDefaults, IdsSize, IdsSizeType } from '@i-cell/ids-angular/core';
 import {
   IDS_ICON_BUTTON_PARENT,
@@ -14,7 +13,6 @@ import {
   IdsIconButtonVariantType,
   IdsIconButtonParent,
 } from '@i-cell/ids-angular/icon-button';
-import { filter } from 'rxjs';
 
 const defaultConfig = IDS_SIDE_NAV_DEFAULT_CONFIG_FACTORY();
 
@@ -57,8 +55,6 @@ export class IdsSideNavComponent extends ComponentBaseWithDefaults<IdsSideNavDef
   public variant = input<IdsSideNavVariantType>(this._defaultConfig.variant);
   public hasActiveIndicator = input<unknown, boolean>(this._defaultConfig.hasActiveIndicator, { transform: booleanAttribute });
   public hasLabel = input<unknown, boolean>(this._defaultConfig.hasLabel, { transform: booleanAttribute });
-  public navigationChange = toSignal(this._router.events.pipe(filter((event) => event instanceof NavigationEnd)));
-
   public embeddedIconButtonAppearance = computed<IdsIconButtonAppearanceType>(() => this.appearance());
   public embeddedIconButtonVariant = computed<IdsIconButtonVariantType>(() => this.variant());
   public embeddedIconButtonSize = computed<IdsSizeType>(() => {


### PR DESCRIPTION
note: former isActive function is deprecated from Angular 21.1, so it has been replaced with isActive signal