### PR TITLE
fix: dialog now uses global backdrop to eliminate that the overlay-panels remain interactive

### DIFF
--- a/projects/demo/src/app/pages/dialog/dialog-demo.component.html
+++ b/projects/demo/src/app/pages/dialog/dialog-demo.component.html
@@ -7,9 +7,8 @@
             Open static dialog
           </button>
 
-          <dialog
+          <ids-dialog
             #dialogStatic="idsDialog"
-            idsDialog
             [size]="_dialogDemoService.model.size"
             [mainTitle]="_dialogDemoService.model.mainTitle"
             [subTitle]="_dialogDemoService.model.subTitle"
@@ -154,7 +153,7 @@
                 OK
               </button>
             </ng-container>
-          </dialog>
+          </ids-dialog>
         </div>
 
         <div class="dialog-type">
@@ -164,24 +163,6 @@
         </div>
       </div>
     </app-tryout>
-
-    <dialog #dialog5="idsDialog" idsDialog mainTitle="Dialog with scrollable content" subTitle="Dialog sub-title here">
-      <!-- content -->
-      <div idsDialogContent></div>
-      <!-- action buttons -->
-      <div idsDialogActions class="dialog-with-scrollable-content">
-        <button
-          type="button"
-          idsButton
-          appearance="filled"
-          size="comfortable"
-          variant="primary"
-          (click)="onOkButtonClick('some payload'); dialog5.close()"
-        >
-          OK
-        </button>
-      </div>
-    </dialog>
   </div>
 
   <div controls class="h-full">

--- a/projects/demo/src/app/pages/dialog/dialog-demo.component.ts
+++ b/projects/demo/src/app/pages/dialog/dialog-demo.component.ts
@@ -23,9 +23,8 @@ export const CUSTOM_DIALOG_TOKEN = new InjectionToken<string>('ids-custom-dialog
   template: `
     @let controls = dialogDemoService.model;
     @let helperControls = dialogDemoService.helperModel;
-    <dialog
+    <ids-dialog
       #dialogDynamic="idsDialog"
-      idsDialog
       [size]="controls!.size"
       [mainTitle]="controls!.mainTitle"
       [subTitle]="controls!.subTitle"
@@ -158,7 +157,7 @@ export const CUSTOM_DIALOG_TOKEN = new InjectionToken<string>('ids-custom-dialog
           OK
         </button>
       </ng-container>
-    </dialog>
+    </ids-dialog>
   `,
   styles: `
     p {
@@ -174,7 +173,7 @@ export const CUSTOM_DIALOG_TOKEN = new InjectionToken<string>('ids-custom-dialog
 export class CustomDialogComponent extends IdsCustomDialogBase {
   public providedData = inject(CUSTOM_DIALOG_TOKEN);
   public inputData = input('');
-  public dialogDemoService = inject(DialogDemoService);
+  public dialogDemoService = inject<DialogDemoService>(DialogDemoService);
 }
 
 @Component({
@@ -219,8 +218,9 @@ export class DialogDemoComponent {
       ],
       inputs: {
         inputData: 'This text is provided using input binding',
-
       },
+      showBackdrop: this._dialogDemoService.model.showBackdrop,
+      size: this._dialogDemoService.model.size,
     }).subscribe((result) => console.info('Dialog result:', result));
   }
 }

--- a/projects/widgets/dialog/custom-dialog-base.ts
+++ b/projects/widgets/dialog/custom-dialog-base.ts
@@ -1,35 +1,10 @@
-import { IdsDialogComponent } from './dialog.component';
+import { DialogRef } from '@angular/cdk/dialog';
+import { inject } from '@angular/core';
 
-import { AfterViewInit, Directive, OnDestroy, viewChild } from '@angular/core';
-import { Subject, Subscription, fromEvent } from 'rxjs';
+export abstract class IdsCustomDialogBase<R = unknown> {
+  protected readonly _dialogRef = inject<DialogRef<R | undefined>>(DialogRef, { optional: true });
 
-@Directive({ standalone: true })
-export abstract class IdsCustomDialogBase<ResultType = unknown> implements AfterViewInit, OnDestroy {
-  public dialogResult = new Subject<ResultType | undefined>();
-
-  protected _dialog = viewChild.required(IdsDialogComponent);
-
-  private _closeSub?: Subscription;
-
-  public ngAfterViewInit(): void {
-    this._dialog().open();
-    this._closeSub = fromEvent(this._dialog().dialog, 'close').subscribe(() => {
-      this._setDialogResult();
-    });
-  }
-
-  public ngOnDestroy(): void {
-    this._closeSub?.unsubscribe();
-  }
-
-  public close(payload?: ResultType): void {
-    this._closeSub?.unsubscribe();
-    this._dialog().close();
-    this._setDialogResult(payload);
-  }
-
-  private _setDialogResult(payload?: ResultType): void {
-    this.dialogResult.next(payload);
-    this.dialogResult.complete();
+  public close(result?: R): void {
+    this._dialogRef?.close(result);
   }
 }

--- a/projects/widgets/dialog/dialog.component.html
+++ b/projects/widgets/dialog/dialog.component.html
@@ -1,37 +1,47 @@
-<section class="ids-dialog-container">
-  <header class="ids-dialog-header">
-    @if (_customHeader()) {
-      <ng-container [ngTemplateOutlet]="_customHeader()!.template" />
-    } @else {
-      <div class="ids-dialog-header-default-content">
-        <h2 class="ids-dialog-title" [id]="_titleId()">{{ mainTitle() }}</h2>
-        @if (subTitle()) {
-          <h3 class="ids-dialog-subtitle">{{ subTitle() }}</h3>
-        }
-      </div>
-    }
+@if (_isStaticDialog()) {
+  <ng-template #dialogTemplate>
+    <ng-container [ngTemplateOutlet]="template" />
+  </ng-template>
+} @else {
+  <ng-container [ngTemplateOutlet]="template" />
+}
 
-    @if (showCloseButton()) {
-      <button
-        type="button"
-        class="ids-dialog-close-button"
-        idsIconButton
-        appearance="standard"
-        size="compact"
-        variant="surface"
-        [disabled]="isCloseButtonDisabled()"
-        (click)="close()"
-      >
-        <ids-icon aria-hidden="true" alt="" fontIcon="close" />
-      </button>
-    }
-  </header>
-  <div class="ids-dialog-content" [class.ids-dialog-content-scrollable]="scrollDetector.isScrollable()">
-    <div #scrollDetector="idsDetectScrollable" idsDetectScrollable class="ids-dialog-content-overflow">
-      <ng-content select="[idsDialogContent]" />
+<ng-template #template>
+  <section class="ids-dialog-container">
+    <header class="ids-dialog-header">
+      @if (_customHeader()) {
+        <ng-container [ngTemplateOutlet]="_customHeader()!.template" />
+      } @else {
+        <div class="ids-dialog-header-default-content">
+          <h2 class="ids-dialog-title" [id]="_titleId()">{{ mainTitle() }}</h2>
+          @if (subTitle()) {
+            <h3 class="ids-dialog-subtitle">{{ subTitle() }}</h3>
+          }
+        </div>
+      }
+
+      @if (showCloseButton()) {
+        <button
+          type="button"
+          class="ids-dialog-close-button"
+          idsIconButton
+          appearance="standard"
+          size="compact"
+          variant="surface"
+          [disabled]="isCloseButtonDisabled()"
+          (click)="close()"
+        >
+          <ids-icon aria-hidden="true" alt="" fontIcon="close" />
+        </button>
+      }
+    </header>
+    <div class="ids-dialog-content" [class.ids-dialog-content-scrollable]="scrollDetector.isScrollable()">
+      <div #scrollDetector="idsDetectScrollable" idsDetectScrollable class="ids-dialog-content-overflow">
+        <ng-content select="[idsDialogContent]" />
+      </div>
     </div>
-  </div>
-  <footer class="ids-dialog-actions">
-    <ng-content select="[idsDialogActions]" />
-  </footer>
-</section>
+    <footer class="ids-dialog-actions">
+      <ng-content select="[idsDialogActions]" />
+    </footer>
+  </section>
+</ng-template>

--- a/projects/widgets/dialog/dialog.component.ts
+++ b/projects/widgets/dialog/dialog.component.ts
@@ -1,18 +1,18 @@
 import { IDS_DIALOG_DEFAULT_CONFIG, IDS_DIALOG_DEFAULT_CONFIG_FACTORY, IdsDialogDefaultConfig } from './dialog-defaults';
 import { IdsDialogHeaderDirective } from './dialog-header.directive';
 
-import { OverlayContainer } from '@angular/cdk/overlay';
+import { Dialog, DialogRef } from '@angular/cdk/dialog';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
+  TemplateRef,
   ViewEncapsulation,
   computed,
   contentChild,
   inject,
   input,
-  OnDestroy,
+  viewChild,
 } from '@angular/core';
 import { ComponentBaseWithDefaults, IdsDetectScrollableDirective, IdsSizeType } from '@i-cell/ids-angular/core';
 import { IdsIconComponent } from '@i-cell/ids-angular/icon';
@@ -21,7 +21,7 @@ import { IdsIconButtonComponent } from '@i-cell/ids-angular/icon-button';
 const defaultConfig = IDS_DIALOG_DEFAULT_CONFIG_FACTORY();
 
 @Component({
-  selector: 'dialog[idsDialog]',
+  selector: 'ids-dialog, [idsDialog]',
   imports: [
     IdsDetectScrollableDirective,
     IdsIconComponent,
@@ -33,24 +33,22 @@ const defaultConfig = IDS_DIALOG_DEFAULT_CONFIG_FACTORY();
   changeDetection: ChangeDetectionStrategy.OnPush,
   exportAs: 'idsDialog',
   host: {
+    '[class]': '_hostClasses()',
+    '[attr.role]': '"dialog"',
+    '[attr.aria-modal]': '"true"',
     '[attr.aria-labelledby]': '_titleId()',
-    '(cancel)': '_onCancel($event)',
-    '(close)': '_onNativeClose()',
   },
 })
-export class  IdsDialogComponent extends ComponentBaseWithDefaults<IdsDialogDefaultConfig> implements OnDestroy {
+export class IdsDialogComponent extends ComponentBaseWithDefaults<IdsDialogDefaultConfig> {
   protected override get _hostName(): string {
     return 'dialog';
   }
 
+  protected readonly _dialog = inject(Dialog);
   protected readonly _defaultConfig = this._getDefaultConfig(defaultConfig, IDS_DIALOG_DEFAULT_CONFIG);
+  protected _dialogRef = inject<DialogRef<unknown>>(DialogRef, { optional: true });
 
-  public dialog = inject<ElementRef<HTMLDialogElement>>(ElementRef).nativeElement;
-
-  private readonly _overlay = inject(OverlayContainer);
-  private _overlayRoot?: HTMLElement | null;
-  private _overlayPrevParent?: Node | null;
-
+  protected readonly _isStaticDialog = computed(() => this._dialogRef === null);
   protected _titleId = computed(() => `${this.id()}-title`);
   public size = input<IdsSizeType>(this._defaultConfig.size);
   public mainTitle = input.required<string>();
@@ -60,6 +58,7 @@ export class  IdsDialogComponent extends ComponentBaseWithDefaults<IdsDialogDefa
   public showBackdrop = input<boolean>(this._defaultConfig.showBackdrop);
 
   protected _customHeader = contentChild(IdsDialogHeaderDirective);
+  private readonly _template = viewChild.required<TemplateRef<unknown>>('template');
 
   protected _hostClasses = computed(() => this._getHostClasses([
     this.size(),
@@ -71,36 +70,39 @@ export class  IdsDialogComponent extends ComponentBaseWithDefaults<IdsDialogDefa
   }
 
   public open(): void {
-    this.dialog.showModal();
-
-    const root = this._overlay.getContainerElement();
-    if (root && root.parentNode !== this.dialog) {
-      this._overlayRoot = root;
-      this._overlayPrevParent = root.parentNode;
-      this.dialog.appendChild(root);
+    if (this._dialogRef) {
+      return;
     }
+    this._dialogRef = this._dialog.open(this._template(), {
+      hasBackdrop: this.showBackdrop(),
+      disableClose: true,
+      panelClass: [
+        'ids-dialog',
+        `ids-dialog-${this.size()}`,
+        this.showBackdrop() ? 'ids-dialog-with-backdrop' : '',
+      ],
+      backdropClass: this.showBackdrop()
+        ? 'ids-dialog-backdrop'
+        : 'ids-dialog-transparent-backdrop',
+      ariaLabelledBy: this._titleId(),
+      ariaModal: true,
+      restoreFocus: true,
+      autoFocus: 'first-tabbable',
+    });
+
+    this._dialogRef.closed.subscribe(() => {
+      this._dialogRef = null;
+    });
   }
 
-  public close(): void {
-    this.dialog.close();
-    this._restoreOverlay();
+  public close(result?: unknown): void {
+    if (this._dialogRef) {
+      this._dialogRef.close(result);
+    }
   }
 
   protected _onNativeClose(): void {
-    this._restoreOverlay();
   }
 
-  public ngOnDestroy(): void {
-    this._restoreOverlay();
-  }
-
-  private _restoreOverlay(): void {
-    if (this._overlayRoot && this._overlayPrevParent) {
-      try {
-        this._overlayPrevParent.appendChild(this._overlayRoot);
-      } catch { /* empty */ }
-    }
-    this._overlayRoot = null;
-    this._overlayPrevParent = null;
-  }
 }
+

--- a/projects/widgets/dialog/dialog.service.ts
+++ b/projects/widgets/dialog/dialog.service.ts
@@ -1,50 +1,52 @@
 import { IdsCustomDialogBase } from './custom-dialog-base';
 
-import { DOCUMENT } from '@angular/common';
-import { ApplicationRef, EnvironmentInjector, Injectable, Injector, Provider, Signal, StaticProvider, Type, createComponent, inject } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { Injectable, Signal, StaticProvider, Type, inject } from '@angular/core';
+import { IdsSizeType } from '@i-cell/ids-angular/core';
 import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class IdsDialogService {
-  private _appRef = inject(ApplicationRef);
-  private _document = inject(DOCUMENT) as Document;
-  private _injector = inject(EnvironmentInjector);
+  private readonly _dialog = inject(Dialog);
 
   public open<C extends IdsCustomDialogBase<R>, R = unknown>(
     component: Type<C>,
-    options?: { providers?: (Provider | StaticProvider)[], inputs?: { [P in keyof C]?: C[P] extends Signal<infer T> ? T : C[P] } },
-  ): Observable<R | undefined> {
-    let elementInjector = undefined;
-
-    if (options?.providers) {
-      elementInjector = Injector.create({
-        parent: this._injector,
-        providers: options.providers,
-      });
-    }
-
-    const createOptions = {
-      environmentInjector: this._injector,
-      ...(elementInjector && { elementInjector }),
-    };
-    const dialogRef = createComponent(component, createOptions);
-
-    if (options?.inputs) {
-      Object.keys(options.inputs).forEach((key) => dialogRef.setInput(key, options.inputs![key as keyof C]));
-    }
-
-    this._document.body.appendChild(dialogRef.location.nativeElement);
-
-    this._appRef.attachView(dialogRef.hostView);
-
-    const onClose = dialogRef.instance.dialogResult.asObservable();
-
-    onClose.subscribe(() => {
-      this._document.body.removeChild(dialogRef.location.nativeElement);
-      dialogRef.destroy();
+    options?: {
+      providers?: StaticProvider[] | undefined,
+      inputs?: {
+        [P in keyof C]?: C[P] extends Signal<infer T> ? T : C[P];
+      };
+      showBackdrop?: boolean;
+      size?: IdsSizeType;
     },
-    );
+  ): Observable<R | undefined> {
+    const panelClass = [
+      'ids-dialog-overlay-panel',
+      'ids-dialog',
+      options?.showBackdrop === false ? '' : 'ids-dialog-with-backdrop',
+    ];
+    if (options?.size) {
+      panelClass.push(`ids-dialog-${options.size}`);
+    }
+    const dialogRef = this._dialog.open<R | undefined, unknown, C>(component, {
+      hasBackdrop: true,
+      disableClose: true,
+      panelClass,
+      backdropClass: options?.showBackdrop === false
+        ? 'ids-dialog-transparent-backdrop'
+        : 'ids-dialog-backdrop',
+      providers: options?.providers,
+    });
 
-    return onClose;
+    if (options?.inputs && dialogRef.componentRef) {
+      for (const key of Object.keys(options.inputs)) {
+        dialogRef.componentRef.setInput(
+          key,
+          options.inputs[key as keyof C],
+        );
+      }
+    }
+
+    return dialogRef.closed;
   }
 }


### PR DESCRIPTION
IDS-2234

# Breaking Changes

## 1. The native `<dialog>` element is no longer used

The `ids-dialog` component no longer relies on the native HTML `<dialog>` element and has been migrated to Angular CDK Dialog.

Previous usage:

```html
<dialog idsDialog>
  ...
</dialog>
```

New usage:

```html
<ids-dialog>
  ...
</ids-dialog>
```

The `ids-dialog` component is now rendered inside an Angular CDK overlay instead of using the browser's native dialog implementation.

---

## 2. Native dialog APIs are no longer available

The following native `HTMLDialogElement` APIs are no longer supported:

- `show()`
- `showModal()`
- Native `close()` behavior
- Native `cancel` event
- Native `close` event
- `::backdrop` CSS pseudo-element

Dialog opening and closing are now managed by Angular CDK Dialog.

---

## 3. Static dialogs are now internally implemented using Angular CDK Dialog

Static dialogs continue to support the same public API:

```html
<ids-dialog #dialog="idsDialog">
  ...
</ids-dialog>

<button type="button" (click)="dialog.open()">
  Open dialog
</button>
```

However, the implementation has changed internally. Calling `open()` now creates an Angular CDK Dialog instance instead of invoking the native `showModal()` API.

This change improves compatibility with other Angular CDK overlay-based components such as selects, menus, autocomplete panels, and custom overlays.