### PR TITLE
feat(content-card): use anchor instead of button for card link buttons

### DIFF
--- a/projects/demo/src/app/components/content-card/content-card.component.html
+++ b/projects/demo/src/app/components/content-card/content-card.component.html
@@ -70,9 +70,7 @@
       </div>
       @for (button of data.button; track $index) {
         <div class="flex flex-col gap-ids-container-gap-8 justify-end w-full">
-          <button type="button" idsButton size="compact" variant="primary" appearance="outlined" (click)="handleButtonClick(button.url)">
-            {{ button.text }}
-          </button>
+          <a idsButton size="compact" variant="primary" appearance="outlined" [href]="button.url">{{ button.text }}</a>
         </div>
       }
     </div>


### PR DESCRIPTION
#IDS-2458
#IDS-2589
- Replace the button element with (click) handler navigation by a proper anchor tag using [href], consistent with the existing link button in the content card template.