### PR TITLE
fix(dialog): missing size class

### DIFF
--- a/projects/demo/src/app/pages/dialog/dialog-demo.component.ts
+++ b/projects/demo/src/app/pages/dialog/dialog-demo.component.ts
@@ -5,9 +5,10 @@ import { DemoAndCodeComponent } from '../../components/tabs/demo-and-code/demo-a
 import { TryoutControlComponent } from '../../components/tryout/tryout-controls.component';
 import { TryoutComponent } from '../../components/tryout/tryout.component';
 
-import { Component, InjectionToken, inject, input } from '@angular/core';
+import { Component, computed, InjectionToken, inject, input, viewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { IdsButtonComponent } from '@i-cell/ids-angular/button';
+import { IdsSizeType } from '@i-cell/ids-angular/core';
 import { IdsCustomDialogBase, IdsDialogComponent, IdsDialogHeaderDirective, IdsDialogService } from '@i-cell/ids-angular/dialog';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -174,6 +175,9 @@ export class CustomDialogComponent extends IdsCustomDialogBase {
   public providedData = inject(CUSTOM_DIALOG_TOKEN);
   public inputData = input('');
   public dialogDemoService = inject<DialogDemoService>(DialogDemoService);
+
+  private readonly _idsDialog = viewChild(IdsDialogComponent);
+  public override size = computed<IdsSizeType | undefined>(() => this._idsDialog()?.size());
 }
 
 @Component({
@@ -220,7 +224,6 @@ export class DialogDemoComponent {
         inputData: 'This text is provided using input binding',
       },
       showBackdrop: this._dialogDemoService.model.showBackdrop,
-      size: this._dialogDemoService.model.size,
     }).subscribe((result) => console.info('Dialog result:', result));
   }
 }

--- a/projects/widgets/dialog/custom-dialog-base.ts
+++ b/projects/widgets/dialog/custom-dialog-base.ts
@@ -1,8 +1,13 @@
+import { IDS_DIALOG_DEFAULT_CONFIG } from './dialog-defaults';
+
 import { DialogRef } from '@angular/cdk/dialog';
-import { inject } from '@angular/core';
+import { inject, computed } from '@angular/core';
+import { IdsSizeType } from '@i-cell/ids-angular/core';
 
 export abstract class IdsCustomDialogBase<R = unknown> {
   protected readonly _dialogRef = inject<DialogRef<R | undefined>>(DialogRef, { optional: true });
+  public readonly size = computed<IdsSizeType | undefined>(() => this._defaultSize.size);
+  private readonly _defaultSize = inject(IDS_DIALOG_DEFAULT_CONFIG);
 
   public close(result?: R): void {
     this._dialogRef?.close(result);

--- a/projects/widgets/dialog/dialog.service.ts
+++ b/projects/widgets/dialog/dialog.service.ts
@@ -1,8 +1,7 @@
 import { IdsCustomDialogBase } from './custom-dialog-base';
 
-import { Dialog } from '@angular/cdk/dialog';
-import { Injectable, Signal, StaticProvider, Type, inject } from '@angular/core';
-import { IdsSizeType } from '@i-cell/ids-angular/core';
+import { Dialog, DialogRef } from '@angular/cdk/dialog';
+import { Injectable, Signal, StaticProvider, Type, afterNextRender, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
@@ -17,7 +16,6 @@ export class IdsDialogService {
         [P in keyof C]?: C[P] extends Signal<infer T> ? T : C[P];
       };
       showBackdrop?: boolean;
-      size?: IdsSizeType;
     },
   ): Observable<R | undefined> {
     const panelClass = [
@@ -25,9 +23,6 @@ export class IdsDialogService {
       'ids-dialog',
       options?.showBackdrop === false ? '' : 'ids-dialog-with-backdrop',
     ];
-    if (options?.size) {
-      panelClass.push(`ids-dialog-${options.size}`);
-    }
     const dialogRef = this._dialog.open<R | undefined, unknown, C>(component, {
       hasBackdrop: true,
       disableClose: true,
@@ -47,6 +42,25 @@ export class IdsDialogService {
       }
     }
 
+    this._applyDialogSizeFromComponent(dialogRef);
+
     return dialogRef.closed;
+  }
+
+  private _applyDialogSizeFromComponent<R, C extends IdsCustomDialogBase<R>>(
+    dialogRef: DialogRef<R | undefined, C>,
+  ): void {
+    const applySize = (): void => {
+      const resolvedSize = dialogRef.componentInstance?.size();
+      if (resolvedSize != null) {
+        dialogRef.addPanelClass(`ids-dialog-${resolvedSize}`);
+      }
+    };
+
+    if (dialogRef.componentRef) {
+      afterNextRender(applySize, { injector: dialogRef.componentRef.injector });
+    } else {
+      applySize();
+    }
   }
 }


### PR DESCRIPTION
IDS-2584

### Breaking changes: 
- IdsDialogService.open() no longer accepts a size option. Overlay panel size is now taken from IdsCustomDialogBase.size(). Override size on your custom dialog component if you need a non-default size.